### PR TITLE
fix flow of commands

### DIFF
--- a/app/src/main/java/app/nameplaceholder/sensorsapp/App.kt
+++ b/app/src/main/java/app/nameplaceholder/sensorsapp/App.kt
@@ -1,6 +1,8 @@
 package app.nameplaceholder.sensorsapp
 
 import android.app.Application
+import android.content.Intent
+import androidx.core.content.ContextCompat
 
 class App : Application() {
 
@@ -10,6 +12,7 @@ class App : Application() {
         super.onCreate()
         instance = this
         bindNotificationState(this)
+        ContextCompat.startForegroundService(this, Intent(this, ForegroundService::class.java))
     }
 
     companion object {

--- a/app/src/main/java/app/nameplaceholder/sensorsapp/DataRepository.kt
+++ b/app/src/main/java/app/nameplaceholder/sensorsapp/DataRepository.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.*
 class DataRepository constructor(
     private val context: Context
 ) {
+    private val valuesInMemoryCache = mutableListOf<SensorData>()
 
     private var trackingChannel: BroadcastChannel<List<SensorData>>? = null
         get() {
@@ -37,7 +38,6 @@ class DataRepository constructor(
         }
 
     private fun createTrackingChannel(): BroadcastChannel<List<SensorData>> {
-        val valuesInMemoryCache = mutableListOf<SensorData>()
 
         return flow {
             emit(provideBluetoothData().sample(1000))
@@ -45,7 +45,8 @@ class DataRepository constructor(
             emit(provideLocation())
         }
             .flattenMerge()
-            .map { valuesInMemoryCache.add(it); valuesInMemoryCache.toList() }
+            .onEach { valuesInMemoryCache.add(it) }
+            .map { valuesInMemoryCache.toList() }
             .broadcastIn(scope = GlobalScope)
     }
 

--- a/app/src/main/java/app/nameplaceholder/sensorsapp/ForegroundService.kt
+++ b/app/src/main/java/app/nameplaceholder/sensorsapp/ForegroundService.kt
@@ -21,6 +21,7 @@ class ForegroundService : Service() {
     override fun onDestroy() {
         super.onDestroy()
         isActiveChannel.offer(false)
+        stopForeground(true)
     }
 
     override fun onBind(intent: Intent?): IBinder? {

--- a/app/src/main/java/app/nameplaceholder/sensorsapp/MainActivity.kt
+++ b/app/src/main/java/app/nameplaceholder/sensorsapp/MainActivity.kt
@@ -32,8 +32,6 @@ class MainActivity : AppCompatActivity(), CoroutineScope {
                                 .joinToString(separator = "\n") { sensorData -> sensorData.getPrintable() }
                         }
                     }
-                } else {
-                    App.instance.repository.stop()
                 }
             }
         }

--- a/app/src/main/java/app/nameplaceholder/sensorsapp/NotificationUpdater.kt
+++ b/app/src/main/java/app/nameplaceholder/sensorsapp/NotificationUpdater.kt
@@ -25,6 +25,7 @@ fun bindNotificationState(context: Context) {
             if (isActive) {
                 App.instance.repository.track()
             } else {
+                App.instance.repository.stop()
                 emptyFlow()
             }
         }.collect {

--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.31'
+    ext.kotlin_version = '1.3.41'
     repositories {
         google()
         jcenter()
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.5.0-rc03'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
What's up doc?

So, I found this sample in the internet and felt it could get some love.

This PR:
- Leave the add/remove notification to the service. This will remove the notification when the service is stoped.

- The Activity only start/stop the service. The isActive flow will emit to the notificationUpdater and the tracking can start/stop there.

When the Activity called `App.instance.repository.stop()` it would make the tracking stop, but there is no need to call it, as the Activity already stops the service, that will change the state of `isActive` to false, that will stop the repository.

